### PR TITLE
Fix picknik_registration gcov linking issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,8 +48,10 @@ install(DIRECTORY config DESTINATION share/${PROJECT_NAME})
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
-  add_subdirectory(test)
   ament_lint_auto_find_test_dependencies()
+  add_subdirectory(test)
+  target_compile_options(picknik_registration PRIVATE -fprofile-arcs -ftest-coverage)
+  target_link_options(picknik_registration PRIVATE -fprofile-arcs -ftest-coverage)
 endif()
 
 # Export the behavior plugins defined in this package so they are available to


### PR DESCRIPTION
Without this change Pro crashes when any UR configs are run with the following error
```
agent_bridge-1  | [objective_server_node_main-6] [ERROR] [1727456464.458809171] [objective_server_node]: Failed to register provided behavior loader plugins: Failed to load library with name `picknik_registration::PicknikRegistrationBehaviorsLoader`: Failed to load library /home/demo/user_ws/install/picknik_registra
tion/lib/libpicknik_registration.so. Make sure that you are calling the PLUGINLIB_EXPORT_CLASS macro in the library code, and that names are consistent between this macro and your XML. Error string: Could not load library dlopen error: /home/demo/user_ws/install/picknik_registration/lib/libpicknik_registration.so: u
ndefined symbol: __gcov_merge_add, at ./src/shared_library.c:99
```