### PR TITLE
Depend on moveit_ros_planning_interface in package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -14,6 +14,7 @@
 
   <depend>moveit_studio_behavior_interface</depend>
   <depend>perception_pcl</depend>
+  <depend>moveit_ros_planning_interface</depend>
   <depend>moveit_studio_vision_msgs</depend>
   <depend>moveit_studio_vision</depend>
 


### PR DESCRIPTION
It's required by cmake and currently breaking my build.